### PR TITLE
new blueprint ID

### DIFF
--- a/webapp/api/deploy.js
+++ b/webapp/api/deploy.js
@@ -7,7 +7,7 @@ const SPACELIFT_API_KEY_ID = process.env.SPACELIFT_API_KEY_ID;
 const SPACELIFT_API_KEY_SECRET = process.env.SPACELIFT_API_KEY_SECRET;
 
 // Blueprint ID
-const BLUEPRINT_ID = process.env.BLUEPRINT_ID || 'minesible-blueprint-01K0CMV29TNE4365427CKCMFH5';
+const BLUEPRINT_ID = process.env.BLUEPRINT_ID || 'minesible-blueprint-v2-01K0T0Z6H7XYTDEN4ST1D4SEXE';
 
 // Validate required environment variables
 if (!SPACELIFT_API_URL || !SPACELIFT_API_KEY_ID || !SPACELIFT_API_KEY_SECRET) {

--- a/webapp/api/index.js
+++ b/webapp/api/index.js
@@ -103,7 +103,7 @@ async function spaceliftQuery(query, variables = {}) {
 }
 
 // Blueprint ID
-const BLUEPRINT_ID = 'minesible-blueprint-01K0CMV29TNE4365427CKCMFH5';
+const BLUEPRINT_ID = 'minesible-blueprint-v2-01K0T0Z6H7XYTDEN4ST1D4SEXE';
 
 // API Routes
 


### PR DESCRIPTION
Ansible runner images got updated yesterday.
New update did not include the SPACELIFT user and defualt user had blocked access to /tmp directory.

Change the blueprint to use the legacy runner image:

```
  ansible:
    playbook: playbook.yml
    runner_image: public.ecr.aws/spacelift/runner-ansible:legacy
```

Updated new blueprint ID in git repo referencing the old ID